### PR TITLE
Update the go-pkg-xmlx dependency.

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -1,6 +1,6 @@
 package feeder
 
-import xmlx "github.com/jteeuwen/go-pkg-xmlx"
+import xmlx "github.com/muesli/go-pkg-xmlx"
 
 func (this *Feed) readAtom(doc *xmlx.Document) (err error) {
 	ns := "http://www.w3.org/2005/Atom"

--- a/feed.go
+++ b/feed.go
@@ -1,6 +1,6 @@
 /*
  Author: jim teeuwen <jimteeuwen@gmail.com>
- Dependencies: go-pkg-xmlx (http://github.com/jteeuwen/go-pkg-xmlx)
+ Dependencies: go-pkg-xmlx (http://github.com/muesli/go-pkg-xmlx)
 
  This package allows us to fetch Rss and Atom feeds from the internet.
  They are parsed into an object tree which is a hybrid of both the RSS and Atom
@@ -32,7 +32,7 @@ import (
 	"strings"
 	"time"
 
-	xmlx "github.com/jteeuwen/go-pkg-xmlx"
+	xmlx "github.com/muesli/go-pkg-xmlx"
 )
 
 type UnsupportedFeedError struct {

--- a/rss.go
+++ b/rss.go
@@ -1,7 +1,7 @@
 package feeder
 
 import (
-	xmlx "github.com/jteeuwen/go-pkg-xmlx"
+	xmlx "github.com/muesli/go-pkg-xmlx"
 )
 
 type MissingRssNodeError struct{}


### PR DESCRIPTION
Update the go-pkg-xmlx dependency to point to github.com/muesli
instead of jteewen/go-pkg-xmlx. The latest has been deleted from
github.